### PR TITLE
Fix u12 argument check

### DIFF
--- a/modules/sanity_check_functions.py
+++ b/modules/sanity_check_functions.py
@@ -57,7 +57,7 @@ def check_2bit_file_completeness(two_bit_file, chroms_sizes, chrom_file):
     return
 
 
-def check_and_write_u12_file(t_in_bed, u12_arg, temp_wd):
+def check_and_write_u12_file(u12_arg, t_in_bed, temp_wd):
     """Sanity check for U12 file."""
     if u12_arg is None:
         return None

--- a/toga.py
+++ b/toga.py
@@ -381,19 +381,19 @@ class Toga:
         self.LOCATION = os.path.dirname(__file__)  # folder containing pipeline scripts
         self.CONFIGURE = os.path.join(self.LOCATION, "configure.sh")
         self.CHAIN_SCORE_FILTER = os.path.join(
-            self.LOCATION, "modules", "chain_score_filter"
+            self.LOCATION, Constants.MODULES_DIR, "chain_score_filter"
         )
         self.CHAIN_SCORE_FILTER_AWK = os.path.join(
-            self.LOCATION, "modules", "chain_score_filter.awk"
+            self.LOCATION, Constants.MODULES_DIR, "chain_score_filter.awk"
         )
         self.CHAIN_COORDS_CONVERT_LIB = os.path.join(
-            self.LOCATION, "modules", "chain_coords_converter_slib.so"
+            self.LOCATION, Constants.MODULES_DIR, "chain_coords_converter_slib.so"
         )
         self.EXTRACT_SUBCHAIN_LIB = os.path.join(
-            self.LOCATION, "modules", "extract_subchain_slib.so"
+            self.LOCATION, Constants.MODULES_DIR, "extract_subchain_slib.so"
         )
         self.CHAIN_FILTER_BY_ID = os.path.join(
-            self.LOCATION, "modules", "chain_filter_by_id"
+            self.LOCATION, Constants.MODULES_DIR, "chain_filter_by_id"
         )
         self.CHAIN_BDB_INDEX = os.path.join(
             self.LOCATION, Constants.MODULES_DIR, "chain_bst_index.py"

--- a/toga.py
+++ b/toga.py
@@ -170,7 +170,7 @@ class Toga:
         # mics things
         self.isoforms_arg = args.isoforms if args.isoforms else None
         self.isoforms = None  # will be assigned after completeness check
-        self.u12_arg = args.u12
+        self.u12_arg = args.u12 if args.u12 else None
         self.u12 = None  # assign after U12 file check
         self.chain_jobs = args.chain_jobs_num
         self.cesar_binary = (

--- a/toga.py
+++ b/toga.py
@@ -170,6 +170,8 @@ class Toga:
         # mics things
         self.isoforms_arg = args.isoforms if args.isoforms else None
         self.isoforms = None  # will be assigned after completeness check
+        self.u12_arg = args.u12
+        self.u12 = None  # assign after U12 file check
         self.chain_jobs = args.chain_jobs_num
         self.cesar_binary = (
             self.DEFAULT_CESAR if not args.cesar_binary else args.cesar_binary
@@ -246,9 +248,7 @@ class Toga:
             self.temp_wd, Constants.CESAR_PRECOMPUTED_MEMORY_DATA
         )
         self.precomp_reg_dir = None
-        self.cesar_mem_was_precomputed = False
-        self.u12_arg = args.u12
-        self.u12 = None  # assign after U12 file check
+        self.cesar_mem_was_precomputed = False       
 
         # genes to be classified as missing
         self._transcripts_not_intersected = []
@@ -355,7 +355,7 @@ class Toga:
             # to compare chrom lengths with 2bit
             chrom_sizes_in_bed = {x: None for x in chroms_in_bed}
         self.isoforms = check_isoforms_file(self.isoforms_arg, t_in_bed, self.temp_wd)
-        self.u12 = check_and_write_u12_file(t_in_bed, self.u12_arg, self.temp_wd)
+        self.u12 = check_and_write_u12_file(self.u12_arg, t_in_bed, self.temp_wd)
         check_2bit_file_completeness(self.t_2bit, chrom_sizes_in_bed, self.ref_bed)
         # need to check that chain chroms and their sizes match 2bit file data
         with open(self.chain_file, "r") as f:

--- a/toga.py
+++ b/toga.py
@@ -329,13 +329,13 @@ class Toga:
     def __check_param_files(self):
         """Check that all parameter files exist."""
         files_to_check = [
-            self.u12,
             self.t_2bit,
             self.q_2bit,
             self.cesar_binary,
             self.ref_bed,
             self.chain_file,
             self.isoforms_arg,
+            self.u12_arg,
         ]
         for item in files_to_check:
             if not item:


### PR DESCRIPTION
Hello,

I was looking at __check_param_files and noticed that it checks self.u12 instead of self.u12 arg.

```python
self.u12_arg = args.u12
self.u12 = None  # assign after U12 file check
```

```python
def __check_param_files(self):
        """Check that all parameter files exist."""
        files_to_check = [
            self.u12,
            self.t_2bit,
            self.q_2bit,
            self.cesar_binary,
            self.ref_bed,
            self.chain_file,
            self.isoforms_arg,
        ]
```

So it won't actually catch if the u12 arg isn't a file.

This PR fixes that and also changes the way TOGA handles u12 so that it's more uniform to how it handles isoforms. Nothing big just:

```python
        self.isoforms_arg = args.isoforms if args.isoforms else None
        self.isoforms = None  # will be assigned after completeness check
        self.u12_arg = args.u12 if args.u12 else None
        self.u12 = None  # assign after U12 file check
```
The assignments to variables are moved next to each other and self.u12_arg is set to None if not provided, and:

```python
self.isoforms = check_isoforms_file(self.isoforms_arg, t_in_bed, self.temp_wd)
self.u12 = check_and_write_u12_file(self.u12_arg, t_in_bed, self.temp_wd)

check_and_write_u12_file(u12_arg, t_in_bed, temp_wd):
```

The arguments for check_and_write_u12_file are rearranged to match check_isoforms_file.