### PR TITLE
add gene_prefix argument

### DIFF
--- a/toga.py
+++ b/toga.py
@@ -168,6 +168,7 @@ class Toga:
         )
 
         # mics things
+        self.gene_prefix = args.gene_prefix
         self.isoforms_arg = args.isoforms if args.isoforms else None
         self.isoforms = None  # will be assigned after completeness check
         self.chain_jobs = args.chain_jobs_num
@@ -1550,6 +1551,7 @@ class Toga:
             self.query_annotation,
             query_isoforms_file,
             save_genes_track=query_gene_spans,
+            gene_prefix=self.gene_prefix,
         )
         to_log("Calling orthology types mapping step...")
         skipped_ref_trans = os.path.join(self.wd, "ref_orphan_transcripts.txt")
@@ -1719,6 +1721,12 @@ def parse_args():
         "create project directory in the current directory as "
         '"CURRENT_DIR/PROJECT_NAME". If not provided, TOGA will try to extract '
         "the project name from chain filename, which is not recommended.",
+    )
+    app.add_argument(
+        "--gene_prefix",
+        "--gp",
+        default="TOGA",
+        help="Prefix to use for query gene identifiers. Default value is TOGA",
     )
     app.add_argument(
         "--min_score",


### PR DESCRIPTION
This PR adds a --gene_prefix or --gp argument to TOGA, and changes the relevant functions in make_query_isoforms so that TOGA will use that prefix to name genes. If not provided "TOGA" will be used instead. Also, the gene number is now padded to 11 digits a la Ensembl