### PR TITLE
Uge parallelization

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -32,7 +32,8 @@ class Constants:
 
     NUM_CESAR_MEM_PRECOMP_JOBS = 500
     PARA_STRATEGIES = ["nextflow", "para", "custom"]  # TODO: add snakemake
-
+    CONFIG_STRATEGIES = [] # strategies that need JSON configuration
+    PARA_SCHEMA_DIR = os.path.abspath(os.path.join(LOCATION, "parallel_config/schema"))
     TEMP_CHAIN_CLASS = "temp_chain_trans_class"
     MODULES_DIR = "modules"
     RUNNING = "RUNNING"

--- a/constants.py
+++ b/constants.py
@@ -15,6 +15,7 @@ class Constants:
     ISOFORMS_FILE_COLS = 2
     NF_DIR_NAME = "nextflow_logs"
     NEXTFLOW = "nextflow"
+    GNU_PARALLEL = "parallel"
     CESAR_PUSH_INTERVAL = 30  # CESAR jobs push interval
     ITER_DURATION = 60  # CESAR jobs check interval
     MEMLIM_ARG = "--memlim"
@@ -31,8 +32,8 @@ class Constants:
     CESAR_PRECOMPUTED_ORTHO_LOCI_DATA = "cesar_precomputed_orthologous_loci.tsv"
 
     NUM_CESAR_MEM_PRECOMP_JOBS = 500
-    PARA_STRATEGIES = ["nextflow", "para", "custom"]  # TODO: add snakemake
-    CONFIG_STRATEGIES = [] # strategies that need JSON configuration
+    PARA_STRATEGIES = ["nextflow", "para", "uge", "custom"]  # TODO: add snakemake
+    CONFIG_STRATEGIES = ["uge"] # strategies that need JSON configuration
     PARA_SCHEMA_DIR = os.path.abspath(os.path.join(LOCATION, "parallel_config/schema"))
     PARA_TEMPLATES_DIR = os.path.abspath(os.path.join(LOCATION, "parallel_config/templates"))
     TEMP_CHAIN_CLASS = "temp_chain_trans_class"

--- a/constants.py
+++ b/constants.py
@@ -34,6 +34,7 @@ class Constants:
     PARA_STRATEGIES = ["nextflow", "para", "custom"]  # TODO: add snakemake
     CONFIG_STRATEGIES = [] # strategies that need JSON configuration
     PARA_SCHEMA_DIR = os.path.abspath(os.path.join(LOCATION, "parallel_config/schema"))
+    PARA_TEMPLATES_DIR = os.path.abspath(os.path.join(LOCATION, "parallel_config/templates"))
     TEMP_CHAIN_CLASS = "temp_chain_trans_class"
     MODULES_DIR = "modules"
     RUNNING = "RUNNING"

--- a/modules/parallel_jobs_manager_helpers.py
+++ b/modules/parallel_jobs_manager_helpers.py
@@ -1,6 +1,8 @@
 """Helper function related to parallelisation."""
 import time
 import os
+from constants import Constants
+from jinja2 import FileSystemLoader, Environment
 from modules.common import to_log
 
 __author__ = "Bogdan M. Kirilenko"
@@ -35,4 +37,7 @@ def monitor_jobs(jobs_managers, die_if_sc_1=False):
         raise AssertionError(err)
 
 
-
+def load_template(filename):
+    templateLoader = FileSystemLoader(Constants.PARA_TEMPLATES_DIR)
+    templateEnv = Environment(loader=templateLoader, autoescape=True, trim_blocks=True)
+    return templateEnv.get_template(filename)

--- a/modules/parallel_jobs_manager_helpers.py
+++ b/modules/parallel_jobs_manager_helpers.py
@@ -6,7 +6,6 @@ from modules.common import to_log
 __author__ = "Bogdan M. Kirilenko"
 
 ITER_DURATION = 60  # CESAR jobs check interval
-NF_DIR_NAME = "nextflow_logs"
 
 
 def monitor_jobs(jobs_managers, die_if_sc_1=False):
@@ -36,12 +35,4 @@ def monitor_jobs(jobs_managers, die_if_sc_1=False):
         raise AssertionError(err)
 
 
-def get_nextflow_dir(proj_location, nf_dir_arg):
-    """Define nextflow directory."""
-    if nf_dir_arg is None:
-        default_dir = os.path.join(proj_location, NF_DIR_NAME)
-        os.mkdir(default_dir) if not os.path.isdir(default_dir) else None
-        return default_dir
-    else:
-        os.mkdir(nf_dir_arg) if not os.path.isdir(nf_dir_arg) else None
-        return nf_dir_arg
+

--- a/parallel_config/example_config/custom_config.json
+++ b/parallel_config/example_config/custom_config.json
@@ -1,0 +1,17 @@
+{
+    "strat": "custom",
+    "steps": {
+        "chains": {
+
+        },
+        "opt_cesar": {
+
+        },
+        "cesar": {
+
+        },
+        "rerun_cesar": {
+            
+        }
+    }
+}

--- a/parallel_config/example_config/uge_config.json
+++ b/parallel_config/example_config/uge_config.json
@@ -1,0 +1,30 @@
+{
+    "strat": "uge",
+    "qsub_cmd": "qsub_beta",
+    "parallel_env": "def_slot",
+    "mem_args": ["s_vmem", "mem_req"],
+    "time_args": ["d_rt", "l_rt"],
+    "extra_args": null,
+    "steps": [
+        {
+            "step": "extract_chains",
+            "queue": "short.q",
+            "memGB": 10,
+            "extra_args": ["-l short"]
+        },
+        {
+            "step": "run_cesar",
+            "memGB": 64,
+            "conc": 10,
+            "slots": 4,
+            "inc": 25
+        },
+        {
+            "step": "rerun_cesar",
+            "memGB": 64,
+            "conc": 10,
+            "slots": 4,
+            "inc": 25
+        }
+    ]
+}

--- a/parallel_config/example_config/uge_test_config.json
+++ b/parallel_config/example_config/uge_test_config.json
@@ -1,0 +1,34 @@
+{
+    "strat": "uge",
+    "qsub_cmd": "qsub_beta",
+    "parallel_env": "def_slot",
+    "mem_args": ["s_vmem", "mem_req"],
+    "time_args": ["d_rt", "l_rt"],
+    "extra_args": null,
+    "steps": [
+        {
+            "step": "extract_chains",
+            "queue": "short.q",
+            "memGB": 10,
+            "extra_args": ["-l short"]
+        },
+        {
+            "step": "run_cesar",
+            "queue": "short.q",
+            "memGB": 64,
+            "extra_args": ["-l short"],
+            "conc": 10,
+            "slots": 4,
+            "inc": 25
+        },
+        {
+            "step": "rerun_cesar",
+            "queue": "short.q",
+            "memGB": 64,
+            "extra_args": ["-l short"],
+            "conc": 10,
+            "slots": 4,
+            "inc": 25
+        }
+    ]
+}

--- a/parallel_config/schema/custom_schema.json
+++ b/parallel_config/schema/custom_schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Custom config",
+    "description": "Configuration for running TOGA with a custom parallelization strategy",
+    "type": "object",
+    "properties": {
+        "strat": {
+            "description": "The name of the parellization strategy to use",
+            "type": "string",
+            "const": "custom"
+        },
+        "steps": {
+            "description": "separate properties for each step of TOGA",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "uniqueItems": true,
+                "minItems": 3,
+                "properties": {
+                    "step": {
+                        "description": "Name of step",
+                        "enum": ["extract_chains", "run_cesar", "rerun_cesar"]
+                    }
+                },
+                "required": ["step"]
+            }
+        }
+    }
+}

--- a/parallel_config/schema/uge_schema.json
+++ b/parallel_config/schema/uge_schema.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "UGE config",
+    "description": "Configuration for running TOGA on UGE",
+    "type": "object",
+    "properties": {
+        "strat": {
+            "description": "Must be uge",
+            "type": "string",
+            "const": "uge"
+        },
+        "qsub_cmd": {
+            "description": "qsub command to use",
+            "type": "string",
+            "enum": ["qsub", "qsub_beta"],
+            "examples": ["qsub", "qsub_beta"]
+        },
+        "parallel_env": {
+            "description": "Parallel environment to use",
+            "examples": ["def_slot"]
+        },
+        "mem_args": {
+            "description": "List of arguments used to specify memory",
+            "type": ["array", "null"],
+            "examples": ["s_vmem", "mem_req"]
+        },
+        "time_args": {
+            "description": "List of arguments used to specify runtime",
+            "type": ["array", "null"],
+            "examples": ["d_rt", "s_rt"]
+        },
+        "extra_args" : {
+            "description": "Extra arguments to use for all commands",
+            "type": ["array", "null"],
+            "examples": ["-l foo"]
+        },
+        "steps": {
+            "description": "separate properties for each step of TOGA",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "uniqueItems": true,
+                "minItems": 3,
+                "properties": {
+                    "step": {
+                        "description": "Name of step",
+                        "enum": ["extract_chains", "run_cesar", "rerun_cesar"]
+                    },
+                    "queue" : {
+                        "description": "What queue to use, if any",
+                        "type": ["string"]
+                    },
+                    "memGB" : {
+                        "description": "Memory to use for step in GB",
+                        "type": ["integer"]
+                    },
+                    "extra_args" : {
+                        "description": "Extra arguments for chain step",
+                        "type": ["array"],
+                        "examples": ["-l foo"]
+                    },
+                    "runtime": {
+                        "description": "Max time for job to run",
+                        "type": ["string"],
+                        "examples": ["00:10:00"]
+                    },
+                    "conc": {
+                        "description": "Max number of jobs to run at a time",
+                        "type": ["integer"]
+                    },
+                    "slots": {
+                        "description": "Number of slots to use in parallel jobs",
+                        "type": ["integer"],
+                        "exclusiveMinimum": 1
+                    },
+                    "inc": {
+                        "description": "Number of jobs each submission should run",
+                        "type": ["integer"],
+                        "exclusiveMinimum": 1
+                    }
+                },
+                "required": ["step"],
+                "dependentRequired": {
+                    "inc": ["slots"],
+                    "slots": ["inc"]
+                }
+            }
+        }
+    },
+    "required": ["strat", "mem_args", "time_args"],
+    "if": {
+        "properties": {
+            "step_conf": {
+                "contains": {
+                    "type": "object",
+                    "properties" : {
+                        "slots": {
+                            "type": "integer",
+                            "exclusiveMinimum": 1
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "then": {
+        "required": [
+            "parallel_env"
+        ]
+    }
+}

--- a/parallel_config/templates/uge_jobscript.jinja2
+++ b/parallel_config/templates/uge_jobscript.jinja2
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#$ -S /bin/bash
+#$ -N {{ jobname }}
+#$ -o {{ logdir }}/{{ step }}.o
+#$ -e {{ logdir }}/{{ step }}.e
+#$ -V
+#$ -sync y
+{# Queue #}
+{% if queue %}
+#$ -q {{ queue }}
+{% endif %}
+{# Memory #}
+{% if memGB %}
+{% for marg in mem_args %}
+#$ -l {{ marg }}={{ memGB }}G
+{% endfor %}
+{% endif %}
+{# Runtime #}
+{% if runtime %}
+{% for targ in time_args %}
+#$ -l {{ targ }}={{ runtime }}
+{% endfor %}
+{% endif %}
+{# Extra args #}
+{% if l_extra_args %}
+{% for earg in l_extra_args %}
+#$ {{ earg }}
+{% endfor %}
+{% endif %}
+{% if g_extra_args %}
+{% for earg in g_extra_args %}
+#$ {{ earg }}
+{% endfor %}
+{% endif %}
+{# Max array jobs to spawn at a time #}
+{% if conc %}
+#$ -tc {{ conc }}
+{% endif %}
+{# Parallel environment #}
+{% if slots > 1 %}
+#$ -pe {{ penv }} {{ slots }}
+{% endif %}
+{# Either run 1 task per job or inc tasks #}
+#$ -t 1-{{ jobnum }}{% if inc %}:{{ inc }}{% endif %}
+
+
+{% if inc %}
+let QUIT_ID=${SGE_TASK_ID}+{{ inc }}
+let END_ID=${QUIT_ID}-1
+
+sed -n "${SGE_TASK_ID},${END_ID}p;${QUIT_ID}q" {{ joblist }} | 
+{% else %}
+sed -n ${SGE_TASK_ID}p {{ joblist }} |
+{% endif %}
+parallel -j {{ slots }} --halt soon,fail=1 --retries 3 --joblog {{ logdir }}/{{ step }}_${SGE_TASK_ID}.log
+
+exit $?

--- a/parallel_jobs_manager.py
+++ b/parallel_jobs_manager.py
@@ -11,6 +11,8 @@ from abc import ABC, abstractmethod
 import subprocess
 import os
 import shutil
+from jinja2 import Template
+from modules.parallel_jobs_manager_helpers import load_template
 from modules.common import to_log
 from version import __version__
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn==1.2.2
 joblib==1.2.0
 h5py==3.8.0
 jsonschema==4.19.1
+jinja2==3.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ xgboost==1.7.5
 scikit-learn==1.2.2
 joblib==1.2.0
 h5py==3.8.0
+jsonschema==4.19.1

--- a/requirements_conda.yaml
+++ b/requirements_conda.yaml
@@ -18,3 +18,5 @@ dependencies:
   - jinja2==3.1.2
 # For Nextflow
   - nextflow=23.04.3
+# For UGE
+  - parallel=20170422

--- a/requirements_conda.yaml
+++ b/requirements_conda.yaml
@@ -13,5 +13,7 @@ dependencies:
 # Different version from pip
   - h5py==3.3.0
   - py-xgboost=1.7.6
+# New
+  - jsonschema==4.19.1
 # For Nextflow
   - nextflow=23.04.3

--- a/requirements_conda.yaml
+++ b/requirements_conda.yaml
@@ -1,0 +1,17 @@
+name: toga
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - twobitreader==3.1.7
+  - networkx==3.1
+  - pandas==2.0.2
+  - numpy==1.24.3
+  - scikit-learn==1.2.2
+  - joblib==1.2.0
+# Different version from pip
+  - h5py==3.3.0
+  - py-xgboost=1.7.6
+# For Nextflow
+  - nextflow=23.04.3

--- a/requirements_conda.yaml
+++ b/requirements_conda.yaml
@@ -15,5 +15,6 @@ dependencies:
   - py-xgboost=1.7.6
 # New
   - jsonschema==4.19.1
+  - jinja2==3.1.2
 # For Nextflow
   - nextflow=23.04.3

--- a/toga.py
+++ b/toga.py
@@ -45,6 +45,7 @@ from modules.parallel_jobs_manager_helpers import monitor_jobs
 from parallel_jobs_manager import ParallelJobsManager
 from parallel_jobs_manager import NextflowStrategy
 from parallel_jobs_manager import ParaStrategy
+from parallel_jobs_manager import UGEStrategy
 from parallel_jobs_manager import CustomStrategy
 from version import __version__
 
@@ -289,6 +290,8 @@ class Toga:
             selected_strategy = NextflowStrategy()
         elif selected_strategy == "para":
             selected_strategy = ParaStrategy()
+        elif selected_strategy == "uge":
+            selected_strategy = UGEStrategy()
         else:
             selected_strategy = CustomStrategy()
         jobs_manager = ParallelJobsManager(selected_strategy)
@@ -452,6 +455,14 @@ class Toga:
             msg = (
                 "Error! Cannot find nextflow executable. Please make sure you "
                 "have a nextflow binary in a directory listed in your $PATH"
+            )
+            self.die(msg)
+
+        not_gnu_parallel = shutil.which(Constants.GNU_PARALLEL) is None
+        if self.para_strategy == "uge" and not_gnu_parallel:
+            msg = (
+                "Error! Cannot find gnu parallel executable. Please make sure you "
+                "have gnu parallel in a directory listed in your $PATH"
             )
             self.die(msg)
 


### PR DESCRIPTION
Here's my attempt at adding UGE (Univa Grid Engine) as a parallelization strategy to TOGA. It ended up being pretty big, so I tried splitting it into commits that hopefully make logical sense.

1. Added a yaml file for running TOGA on conda
It uses slightly different versions of some packages but I've been able to run it without issue.

2. Modify how TOGA handles parallelization to prepare for adding another strategy
This involved changing some stuff that was only for nextflow:
nextflow_dir -> para_dir
do_not_del_nf_logs -> do_not_del_para_logs

And creating a function, `__check_para_config`, that checks if the parallelization strategy is allowed, sets parallelization related args to variables, checks nextflow config files, and sets the parts of manager_data that are the same for every step. Basically it gathers a lot of the initial parallelization settings together so they're easier to find and checks for problems before TOGA has done too much.

I also changed the default location of self.nextflow_dir/self.para_dir so that it goes in the working directory instead of the same directory as toga.py

```python
self.nextflow_dir = get_nextflow_dir(self.LOCATION, args.nextflow_dir)
```
becomes
```python
 if args.para_dir is None:
        self.para_dir = os.path.join(self.wd, f"{self.para_strategy}_logs")
    else:
        self.para_dir = args.para_dir
```
It seemed like this would make for easier debugging when running multiple TOGA projects at the same time, but if it causes problems with nextflow then I can separate self.nextflow_dir and self.para_dir

3. Add option for a parallelization strategy to require and validate a JSON config file
Adds two new constants, CONFIG_STRATEGIES and  PARA_SCHEMA_DIR; a new argument, --parallel_config_file; a new function, `__check_para_config_files`; and a new value in manager_data, "para_config". If a parallel strategy is in CONFIG_STRATEGIES then --parallel_config_file must be used to provide a JSON file. This file will be validated using a corresponding schema in PARA_SCHEMA_DIR, and if the file is valid it will be included in manager_data as para_config.

The idea was to provide a way to specify what information a parallelization strategy needs from the user, check that the information makes sense, and provide that information to the parallelization strategy.

4. Add option for a parallelization strategy to load and render a jinja2 template
Created another constant, PARA_TEMPLATES_DIR, and a helper function, load_template, that can load a jinja2 template from this directory.

The idea was to provide a way for parallelization strategies to format things like jobscripts. This commit could probably be replaced with python code if necessary.

5. Add UGEStrategy
Finally I added UGEStrategy. My first concern with writing a UGE strategy for TOGA was making it so that users could easily customize how jobs were submitted. For example, the supercomputer I use UGE on requires you to set the arguments s_vmem and mem_req to the amount of memory you want when submitting a job, but it used to require h_vmem and s_vmem instead. 

So, UGEStrategy requires a JSON config file where you set what memory arguments to use.

My second concern was that UGE doesn't really have a built in way to handle, "here's one file with a list of jobs, do them," gracefully. Basically it has array jobs where you give it a jobscript with the environment variable $SGE_TASK_ID in it and a specify a range, like 1-100. Then it submits the jobscript for every number in that range, substituting the number for $SGE_TASK_ID.

So UGEStrategy creates jobscripts that use sed to get the $SGE_TASK_ID'th line in a joblist.

My third concern was that sometimes it takes a while for a submitted job to start, so it's more efficient if a job runs more than 1 task in parallel.

So, UGEStrategy uses a jinja2 template that can create both jobscripts that run one task for job and jobscripts that run multiple tasks in parallel using GNU parallel depending on what's in the JSON config file.

Unfortunately I didn't noticed that the contribution guidelines had been updated to discourage adding extra dependencies. So this PR ended up adding 3:

1. jsonschema
2. jinja2
3. GNU Parallel

jsonschema would probably need to be replaced by something else if removed, since it handles a lot of making sure the configuration for UGEStrategy is valid.
jinja2 could probably be replaced with a bunch of python code if necessary.
Finally, GNU parallel is only required if using UGEStrategy, similar to how Nextflow is only required if using Nextflow. 

Sorry this ended up being so long!