### PR TITLE
Expose option to include out-of-frame transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ This repository contains examples of bed12 file for human and mouse:
 Some advice about your reference annotation:
 
 - Please make sure that the length of the CDS of your annotations is divisible by 3.
-TOGA will skip transcripts that do not satisfy this criteria.
+By default, TOGA will skip transcripts that do not satisfy this criteria (to override, see the --out_of_frame argument described below).
 - This is highly recommended that CDS of your transcripts start with ATG and end with a canonical stop codon.
 - Your transcripts are coding, meaning that thickStart and thickEnd are not equal.
 TOGA would skip non-coding transcripts.
@@ -448,6 +448,11 @@ files are kept
 Directory containing nextflow configuration files for
 cluster, pls see nextflow_config_files/readme.txt for
 details.
+
+##### --out_of_frame
+
+The default behavior is to ignore transcripts which do not have a CDS length which is a multiple of three.
+Use this optional argument to include those transcripts. 
 
 ## Output reading
 

--- a/toga.py
+++ b/toga.py
@@ -162,7 +162,7 @@ class Toga:
         prepare_bed_file(
             args.bed_input,
             self.ref_bed,
-            ouf=False,  # TODO: check whether we like to include this parameter
+            ouf=args.out_of_frame,
             save_rejected=bed_filt_rejected,
             only_chrom=args.limit_to_ref_chrom,
         )
@@ -1662,6 +1662,12 @@ def parse_args():
             "the reading frame, ignoring ATG codons distribution. "
             "(Default mode in V1.0, not recommended to use in later versions)"
         )
+    )
+    app.add_argument(
+        "--out_of_frame",
+        action="store_true",
+        dest="out_of_frame",
+        help="Do not skip out-of-frame genes.",
     )
     # print help if there are no args
     if len(sys.argv) < 2:


### PR DESCRIPTION
This PR adds the option to include out-of-frame transcripts using a "store_true" command line argument, `---out_of_frame`. Exclusion of out-of-frame transcripts will remain the default behavior, since the default value for store_true if the flag is not specified is False.

I use the human mitochondria genome and transcript BED file (Gencode v44) as MWE. In that BED file, half (six of 13) of the protein-coding genes are "out-of-frame." It seems excessively to disregard half of Gencode transcripts, so I would like the opt-in option to include these out-of-frame transcripts. In fact, the mitochondrial transcript-to-protein-coding-gene mapping is one-to-one, so ignoring out-of-frame transcripts disregards half of Gencode genes (not just half of the transcripts).

I have tested this change on the aforementioned human mitochondria MWE.

The diff is small, because TOGA is very well-written. :) The `--out_of_frame` behavior and flag was already implemented internally in prepare_bed_file. 