### PR TITLE
Update README re loss_summ_data codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,9 @@ TOGA identifies the following classes:
 2) PG - no orthologous chains identified, TOGA projected transcripts via paralogous
 chains and cannot make any conclusion.
 3) PM - partial & missing. Most of the projection lies outside scaffold borders.
-4) L - clearly lost.
-5) M - missing, assembly gaps mask >50% of the prediction CDS.
-6) G - "grey", there are inactivating mutations but not enough evidence
+4) M - missing, assembly gaps mask >50% of the prediction CDS.
+5) L - clearly lost.
+6) UL - "uncertain loss", there are inactivating mutations but not enough evidence
 for "clearly lost" class. In other words: neither lost nor intact.
 7) PI - partially intact: some fraction of CDS is missing, but most likely
 this is intact.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ These jobs are expected to be short and not memory consuming, so 1 hour of runti
 and 10Gb of memory would be enough.
 4) Create "call_cesar_config_template.nf" file.
 This configuration file is for CESAR jobs.
-These jobs usually take much longer that chain feature extraction, it's recommended to request 24 hors for them.
+These jobs usually take much longer that chain feature extraction, it's recommended to request 24 hours for them.
 You don't have to provide an exact amount of memory for these jobs, TOGA will compute this itself.
 Please write a placeholder instead, as follows: process.memory = "${\_MEMORY\_}G".
 
@@ -494,7 +494,7 @@ Isoforms file for the query.
 TOGA produces 3 fasta files: prot.fasta, codon.fasta nucleotide.fasta.
 It saves both the reference and predicted query sequences.
 - prot.fasta contains protein sequences of reference genes and predicted transcripts.
-- codon.fasta contains codon alignments, corrected for frameshiring insertions and deletions
+- codon.fasta contains codon alignments, corrected for frameshifting insertions and deletions
 - nucleotide.fasta contains exon nucleotide alignments
 
 ### orthology_classification.tsv
@@ -649,7 +649,7 @@ you can set the parameter -pre/--precedence like so:
 ./TOGA_assemblyStats.py ${TOGA_DIRS_FILE} -m merge -pre M#PM#PG#abs#I#PI#UL#L
 ```
 
-Note that the ouputs, with the suffix \_merge.tsv, can be renamed loss_summ_data.tsv and put in a directory, to act as the output of a fictional TOGA run.
+Note that the outputs, with the suffix \_merge.tsv, can be renamed loss_summ_data.tsv and put in a directory, to act as the output of a fictional TOGA run.
 This can be useful when using the same script as outlined in the previous section to get summary statistics.
 
 ## Citation


### PR DESCRIPTION
The current version's `loss_summ_data.tsv` outputs a code "UL" which is undocumented in the current README.

The current README describes a `loss_summ_data.tsv` code "G" which is not output by the current version.

It seems the old result code "G" has been replaced by new result code "UL" by an old commit (https://github.com/hillerlab/TOGA/commit/62ef8a39230c78805769d521c3db51e9dbd982b8#). This PR updates the documentation in the README to reflect that change. 