### PR TITLE
Fix ModuleNotFoundError for some scripts in supply/

### DIFF
--- a/supply/mut_index.py
+++ b/supply/mut_index.py
@@ -5,7 +5,6 @@ import os
 from collections import defaultdict
 import numpy as np
 import h5py
-from version import __version__
 
 MUT_LINE_FIELDS = 8
 

--- a/supply/plot_mutations.py
+++ b/supply/plot_mutations.py
@@ -11,7 +11,6 @@ import re
 from copy import copy
 from collections import defaultdict
 import h5py
-from version import __version__
 
 # Mutation classes
 EX_DEL = "Deleted exon"


### PR DESCRIPTION
Fixes #126 by removing the `version.__version__` import. The `version.__version__` variable is not used anywhere in these scripts, anyways.