### PR TITLE
Fix nucleotide.fasta alignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ for_paper/*
 vs_Ensembl/
 vs_Gloss_pipeline/
 sandbox/
+test-*/
 
 2bits/
 ANALYSIS/ENST00000320188.txt.ce

--- a/README.md
+++ b/README.md
@@ -655,10 +655,19 @@ This can be useful when using the same script as outlined in the previous sectio
 ## Contributing
 
 TOGA uses the python built-in [doctest](https://docs.python.org/3/library/doctest.html) framework.
-To run the tests,
+In this framework, tests are embedded within each function's docstring.
+To run all the tests in a file, you could run:
 
-``` shell
-$ python3 -c "import doctest, toga; print(doctest.testmod(toga))"
+```shell
+python3 -m doctest toga.py
+# Or, for verbose output: python3 -m doctest -v toga.py
+```
+
+To run all the tests in all the python files in this project, try:
+
+```shell
+python3 -m doctest $(find . -name "*py")
+# Or, for verbose output: python3 -m doctest -v $(find . -name "*py") 
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -652,6 +652,15 @@ you can set the parameter -pre/--precedence like so:
 Note that the ouputs, with the suffix \_merge.tsv, can be renamed loss_summ_data.tsv and put in a directory, to act as the output of a fictional TOGA run.
 This can be useful when using the same script as outlined in the previous section to get summary statistics.
 
+## Contributing
+
+TOGA uses the python built-in [doctest](https://docs.python.org/3/library/doctest.html) framework.
+To run the tests,
+
+``` shell
+$ python3 -c "import doctest, toga; print(doctest.testmod(toga))"
+```
+
 ## Citation
 
 Kirilenko BM, Munegowda C, Osipova E, Jebb D, Sharma V, Blumer M, Morales AE, Ahmed AW, Kontopoulos DG, Hilgers L, Lindblad-Toh K, Karlsson EK, Zoonomia Consortium, Hiller M. [Integrating gene annotation with orthology inference at scale.](https://www.science.org/stoken/author-tokens/ST-1161/full) Science, 380(6643), eabn3107, 2023

--- a/modules/inact_mut_check.py
+++ b/modules/inact_mut_check.py
@@ -903,7 +903,7 @@ def classify_exons(
         # classify whether it's deleted or not:
         # print(f"Exon {exon_num} classification with the following params: ") if v else None
         # print(ex_class, exon_excl, ex_pid, ex_blosum) if v else None
-        ex_non_del, q = classify_exon(ex_class, exon_excl, ex_pid, ex_blosum, v=v)
+        ex_non_del, q = classify_exon(ex_class, exon_excl, ex_pid, ex_blosum)
         # print(f"Results are: {del_} {q}") if v else None
 
         if ex_class == "M" or ex_gap:

--- a/modules/merge_cesar_output.py
+++ b/modules/merge_cesar_output.py
@@ -204,7 +204,59 @@ def split_ex_reg_in_chrom(exon_regions):
 
 
 def parse_cesar_out_file(arg_input, exclude_arg=None):
-    """Parse CESAR bdb file core function."""
+    r"""Parse CESAR bdb file core function.
+
+    An example of what a "CESAR bdb file" looks like, and how it is parsed:
+
+    >>> from pprint import pprint
+    >>> with open("test-file-400157d.txt", "w") as txtfile:
+    ...     contents = "\n".join([
+    ...         "#ENST00000262455",
+    ...         ">ENST00000262455.1169 | PROT | REFERENCE",
+    ...         "MRVDCDQHSDIAQRYRISK",
+    ...         ">ENST00000262455.1169 | PROT | QUERY",
+    ...         "---------DIAQRYRISK",
+    ...         ">ENST00000262455.1169 | CODON | REFERENCE",
+    ...         "ATG AGA GTT GAT TGT GAT CAG CAC TCT GAC ATA GCC CAG AGA TAC AGG ATA AGC AAA",
+    ...         ">ENST00000262455.1169 | CODON | QUERY",
+    ...         "--- --- --- --- --- --- --- --- --- GAT ATA GCC CAG AGA TAT AGG ATA AGC AAA",
+    ...         ">ENST00000262455 | 0 | 1169 | reference_exon",
+    ...         "ATGAGAGTTGATTGTGATCAGCACT",
+    ...         ">ENST00000262455 | 0 | 1169 | JH567521:510952-510836 | 0.00 | 0.00 | N/A | N/A | exp:N/A-N/A | N/A | False | query_exon",
+    ...         "NNNNNNNNNNNNNNNNNNNNNNNNN",
+    ...         ">ENST00000262455 | 1 | 1169 | reference_exon",
+    ...         "CTGACATAGCCCAGAGATACAGGATAAGCAAA",
+    ...         ">ENST00000262455 | 1 | 1169 | JH567521:506100-505915 | 94.59 | 97.39 | OK | A+ | exp:505909-506110 | INC | False | query_exon",
+    ...         "CTGATATAGCCCAGAGATATAGGATAAGCAAA\n\n",])
+    ...     txtfile.write(contents)
+    822
+    >>> pprint(parse_cesar_out_file("test-file-400157d.txt"))
+    (['JH567521\t505915\t506100\tENST00000262455.1169\t1000\t-\t505915\t506100\t'
+      '0,0,0\t1\t185,\t0,'],
+     ['JH567521\t510952\t510836\tENST00000262455.0.1169\t0\t+\n'],
+     '>ref_ENST00000262455.1169\n'
+     'ATGAGAGTTGATTGTGATCAGCACTCTGACATAGCCCAGAGATACAGGATAAGCAAA\n'
+     '>ENST00000262455.1169\n'
+     '-------------------------CTGATATAGCCCAGAGATATAGGATAAGCAAA\n',
+     'gene\texon_num\tchain_id\tact_region\texp_region\tin_exp\tpid\tblosum\tgap\t'
+     'class\tparalog\tq_mark\n'
+     'ENST00000262455\t0\t1169\tJH567521:510952-510836\texp:N/A-N/A\tN/A\t0.00\t'
+     '0.00\tN/A\tN/A\tFalse\tNA\n'
+     'ENST00000262455\t1\t1169\tJH567521:506100-505915\texp:505909-506110\tINC\t'
+     '94.59\t97.39\tOK\tA+\tFalse\tHQ\n',
+     '>ENST00000262455.1169 | PROT | REFERENCE\n'
+     'MRVDCDQHSDIAQRYRISK\n'
+     '>ENST00000262455.1169 | PROT | QUERY\n'
+     '---------DIAQRYRISK\n',
+     '>ENST00000262455.1169 | CODON | REFERENCE\n'
+     'ATG AGA GTT GAT TGT GAT CAG CAC TCT GAC ATA GCC CAG AGA TAC AGG ATA AGC AAA\n'
+     '>ENST00000262455.1169 | CODON | QUERY\n'
+     '--- --- --- --- --- --- --- --- --- GAT ATA GCC CAG AGA TAT AGG ATA AGC '
+     'AAA\n',
+     '\n',
+     '\n')
+    >>> os.remove("test-file-400157d.txt")"""
+
     # The CESAR output ("bdb") file is divided into sections, one for each
     # reference transcript. Each section start with "#" and "#" is used nowhere
     # else. So, each element of content represents one reference transcript and

--- a/modules/merge_cesar_output.py
+++ b/modules/merge_cesar_output.py
@@ -83,8 +83,16 @@ def parse_args():
     return args
 
 
-def read_fasta(fasta_line, v=False):
-    """Read fasta, return dict and type."""
+def read_fasta(fasta_line: str):
+    r"""Parse a FASTA string.
+
+    The return value is a list of two elements: a dictionary, and list. The keys
+    of the dictionary are the header strings, and the values are the sequences
+    (as strings) of each of those headers. The inner list is a list of strings,
+    where each string is the header string. For example,
+
+    >>> read_fasta("\n".join([">A", "ATC", ">B", "TGG"]))
+    ({'A': 'ATC', 'B': 'TGG'}, ['A', 'B'])"""
     fasta_data = fasta_line.split(">")
     if fasta_data[0] != "":
         # this is a bug
@@ -110,8 +118,11 @@ def read_fasta(fasta_line, v=False):
     return sequences, order
 
 
-def read_region(region):
-    """Return convenient region representation."""
+def read_region(region: str) -> dict:
+    """Return convenient region representation.
+
+    >>> read_region("JH567521:516364-516340")
+    {'chrom': 'JH567521', 'start': 516364, 'end': 516340}"""
     try:
         chrom, grange = region.split(":")
         start = int(grange.split("-")[0])
@@ -192,12 +203,18 @@ def split_ex_reg_in_chrom(exon_regions):
     return chrom_n_to_pieces
 
 
-def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
+def parse_cesar_out_file(arg_input, exclude_arg=None):
     """Parse CESAR bdb file core function."""
-    in_ = open(arg_input, "r")  # read cesar bdb file
-    # two \n\n divide each unit of information
+    # The CESAR output ("bdb") file is divided into sections, one for each
+    # reference transcript. Each section start with "#" and "#" is used nowhere
+    # else. So, each element of content represents one reference transcript and
+    # all its orthologous query transcripts/codons/proteins, encoded as a single
+    # big string; the string is appended with two newlines (\n\n).
+    in_ = open(arg_input, "r")
     content = [x for x in in_.read().split("#") if x]
-    to_log(f"{MODULE_NAME_FOR_LOG}: parsing file {arg_input} with {len(content)} lines")
+    to_log(
+        f"{MODULE_NAME_FOR_LOG}: parsing file {arg_input} with "
+        f"{len(content)} reference transcript(s)")
     in_.close()
     # GLP-related data is already filtered out by cesar_runner
 
@@ -217,9 +234,11 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
 
     for elem in content:
         # one elem - one CESAR call (one ref transcript and >=1 chains)
+        # elem_lines[0] is the reference transcript name; elem_lines[1:] are
+        # alternating FASTA headers and sequences
         elem_lines = [x for x in elem.split("\n") if x != ""]
         # now loop gene-by-gene
-        gene = elem_lines[0].replace("#", "")
+        gene = elem_lines[0]
         if gene in exclude:
             skipped.append(f"{gene}\tfound in the exclude list")
             continue
@@ -228,10 +247,11 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
 
         # basically this is a fasta file with headers
         # saturated with different information
-        sequences, order = read_fasta(cesar_out, v=v)
+        sequences, order = read_fasta(cesar_out)
         # initiate dicts to fill later
         ranges_chain, chain_dir = defaultdict(dict), {}
         pred_seq_chain[gene] = defaultdict(dict)
+        t_exon_seqs[gene] = defaultdict(dict)
 
         # split fasta headers in different classes
         # query, ref and prot sequence headers are explicitly marked
@@ -242,15 +262,15 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
 
         # parse reference exons, quite simple
         for header in ref_headers:
-            # one header for one exon
-            # fields look like this:
-            # FIELD_1 | FIELD_2 | FIELD_3\n
-            header_fields = [s.replace(" ", "") for s in header.split("|")]
+            # Reference exons headers are pipe-delimited with four fields:
+            # (1) reference transcript name, (2) zero-based exon number,
+            # (3) query chain ID, (4) string constant "reference_exon".
+            header_fields = header.split(" | ")
             exon_num = int(header_fields[1])  # 0-based!
-            exon_seq = sequences[header].replace(
-                "-", ""
-            )  # header is also a key for seq dict
-            t_exon_seqs[gene][exon_num] = exon_seq
+            chain_id = int(header_fields[2])
+            exon_seq = sequences[header]
+            # header is also a key for seq dict
+            t_exon_seqs[gene][chain_id][exon_num] = exon_seq
 
         # save protein data
         for prot_id in prot_ids:
@@ -271,7 +291,7 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
         for header in query_headers:
             # the most complicated part: here we extract not only the
             # nucleotide sequence but also coordinates and other features
-            header_fields = [s.replace(" ", "") for s in header.split("|")]
+            header_fields = header.split(" | ")
             if len(header_fields) != Q_HEADER_FIELDS_NUM:
                 continue  # ref exon?
 
@@ -323,12 +343,12 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
             )
             all_meta_data.append(meta_data)
 
-        # check if there are any exons
+        # check if there are any undeleted exons
         for name, stat in gene_chain_exon_status.items():
             any_exons_left = any(stat.values())
             if any_exons_left:
                 continue
-            # projection has no exons: log it
+            # projection has no undeleted exons: log it
             name_ = f"{name[0]}.{name[1]}"
             to_log(f"{MODULE_NAME_FOR_LOG}: Warning: {name_} skipped: all exons are deleted")
             skipped.append(f"{name_}\tall exons are deleted.")
@@ -496,30 +516,39 @@ def parse_cesar_out_file(arg_input, v=False, exclude_arg=None):
     # arrange fasta content
     fasta_lines_lst = []
     to_log(f"{MODULE_NAME_FOR_LOG}: arranging fasta file")
-    for gene, chain_exon_seq in pred_seq_chain.items():
-        # write target gene info
-        t_gene_seq_dct = t_exon_seqs.get(gene)
-        if t_gene_seq_dct is None:
-            # no sequence data for this transcript?
-            to_log(f"{MODULE_NAME_FOR_LOG}: STRONG WARNING! Missing data for {gene} after CESAR")
-            skipped.append(f"{gene}\tmissing data after cesar stage")
-            continue
-        # We have sequence fragments split between different exons
-        t_exon_nums = sorted(t_gene_seq_dct.keys())
-        t_header = ">ref_{0}\n".format(gene)
-        t_seq = "".join([t_gene_seq_dct[num] for num in t_exon_nums]) + "\n"
-        # append data to fasta strings
-        fasta_lines_lst.append(t_header)
-        fasta_lines_lst.append(t_seq)
-
-        # and query info
-        for chain_id, exon_seq in chain_exon_seq.items():
-            track_header = ">{0}.{1}\n".format(gene, chain_id)
-            exon_nums = sorted(exon_seq.keys())
-            # also need to assemble different exon sequences
-            seq = "".join([exon_seq[num] for num in exon_nums]) + "\n"
-            fasta_lines_lst.append(track_header)
-            fasta_lines_lst.append(seq)
+    # Every transcript in CESAR output maps to one /or more/ chains
+    for transcript, qry_chains in pred_seq_chain.items():
+        # chain_id identifies which nucleotide FASTA to get from reference
+        # transcript (via t_exon_seqs). The equivalent for query transcript
+        # is qry_exons (assigned in the for loop). qry_exons only contains
+        # non-deleted exons.
+        for chain_id, qry_exons in qry_chains.items():
+            ref_exons = t_exon_seqs.get(transcript).get(chain_id)
+            if ref_exons is None:
+                to_log(
+                    f"{MODULE_NAME_FOR_LOG}: STRONG WARNING! "
+                    f"Missing data for {transcript} after CESAR")
+                skipped.append(f"{transcript}\tmissing data after cesar stage")
+                continue
+            ref_header = f">ref_{transcript}.{chain_id}\n"
+            # We have sequence fragments split between different exons
+            ref_exon_nums = sorted(ref_exons.keys())
+            exon_deleted_nums = list(set(
+                ref_exons.keys()).difference(qry_exons.keys()))
+            # If the query exon is deleted, it is represented by a gapped
+            # alignment. In this gapped alignment, as is convention, the
+            # reference transcript is ungapped (so, remove dashes), while the
+            # query transcript is all gaps (so, all dashes; as below).
+            ref_seq = "".join([
+                ref_exons[num].replace("-", "") \
+                    if num in exon_deleted_nums else ref_exons[num]
+                    for num in ref_exon_nums]) + "\n"
+            qry_header = f">{transcript}.{chain_id}\n"
+            qry_seq = "".join([
+                "-"*len(ref_exons[num].replace("-", "")) \
+                    if num in exon_deleted_nums else qry_exons[num]
+                    for num in ref_exon_nums]) + "\n"
+            fasta_lines_lst.extend([ref_header, ref_seq, qry_header, qry_seq])
 
     # save corrupted exons as bed-6 track
     # to make it possible to save them and visualize in the browser

--- a/modules/parse_cesar_output.py
+++ b/modules/parse_cesar_output.py
@@ -217,7 +217,9 @@ def parse_args():
     return args
 
 
-def classify_exon(ex_class, incl, pid, blosum, v=False):
+def classify_exon(
+            ex_class: str, incl: bool, pid: float, blosum: float
+        ) -> tuple[bool, str]:
     """Decide what do we do with this exon."""
     # ex_class: how exon aligns
     # A - chain aligns exon perfectly

--- a/split_exon_realign_jobs.py
+++ b/split_exon_realign_jobs.py
@@ -976,7 +976,7 @@ def main():
     )
     to_log(f"{MODULE_NAME_FOR_LOG}: based on memory, the estimated runtime proportions are:")
     for b, prop in buckets_prop.items():
-        to_log(f"* bucke {b}Gb: {prop}")
+        to_log(f"* bucket {b}Gb: {prop}")
     # get number of jobs for each bucket
     bucket_jobs_num = {k: math.ceil(args.jobs_num * v) for k, v in buckets_prop.items()}
     to_log(f"Final numbers of cluster jobs per bucket are:")

--- a/toga.py
+++ b/toga.py
@@ -5,45 +5,46 @@ Perform all operations from the beginning to the end.
 If you need to call TOGA: most likely this is what you need.
 """
 import argparse
-import sys
-import os
-import subprocess
-import time
-from datetime import datetime as dt
-import json
-import shutil
 import importlib.metadata as metadata
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
 from collections import defaultdict
 from constants import Constants
-from modules.filter_bed import prepare_bed_file
+from datetime import datetime as dt
 from modules.bed_hdf5_index import bed_hdf5_index
 from modules.chain_bst_index import chain_bst_index
-from modules.merge_chains_output import merge_chains_output
-from modules.make_pr_pseudogenes_anno import create_ppgene_track
-from modules.merge_cesar_output import merge_cesar_output
-from modules.gene_losses_summary import gene_losses_summary
-from modules.orthology_type_map import orthology_type_map
 from modules.classify_chains import classify_chains
-from modules.make_query_isoforms import get_query_isoforms_data
-from modules.collect_prefefined_glp_classes import collect_predefined_glp_cases
 from modules.collect_prefefined_glp_classes import add_transcripts_to_missing
-from modules.stitch_fragments import stitch_scaffolds
-from modules.common import to_log
-from modules.common import setup_logger
-from modules.common import make_symlink
-from modules.common import get_fst_col
+from modules.collect_prefefined_glp_classes import collect_predefined_glp_cases
 from modules.common import get_bucket_value
+from modules.common import get_fst_col
+from modules.common import make_symlink
 from modules.common import read_chain_arg
+from modules.common import setup_logger
+from modules.common import to_log
+from modules.filter_bed import prepare_bed_file
+from modules.gene_losses_summary import gene_losses_summary
+from modules.make_pr_pseudogenes_anno import create_ppgene_track
+from modules.make_query_isoforms import get_query_isoforms_data
+from modules.merge_cesar_output import merge_cesar_output
+from modules.merge_chains_output import merge_chains_output
+from modules.orthology_type_map import orthology_type_map
+from modules.parallel_jobs_manager_helpers import get_nextflow_dir
+from modules.parallel_jobs_manager_helpers import monitor_jobs
 from modules.sanity_check_functions import check_2bit_file_completeness
 from modules.sanity_check_functions import check_and_write_u12_file
-from modules.sanity_check_functions import check_isoforms_file
 from modules.sanity_check_functions import check_chains_classified
-from modules.parallel_jobs_manager_helpers import monitor_jobs
-from modules.parallel_jobs_manager_helpers import get_nextflow_dir
-from parallel_jobs_manager import ParallelJobsManager
+from modules.sanity_check_functions import check_isoforms_file
+from modules.stitch_fragments import stitch_scaffolds
+from parallel_jobs_manager import CustomStrategy
 from parallel_jobs_manager import NextflowStrategy
 from parallel_jobs_manager import ParaStrategy
-from parallel_jobs_manager import CustomStrategy
+from parallel_jobs_manager import ParallelJobsManager
+from typing import Optional
 from version import __version__
 
 
@@ -557,8 +558,31 @@ class Toga:
             return os.path.abspath(os.readlink(with_alias))
         self.die(f"Two bit file {db} not found! Abort")
 
-    def run(self):
-        """Run toga. Method to be called."""
+    def run(self, up_to_and_incl: Optional[int]=None) -> None:
+        """Run TOGA from start to finish, or from start to a certain step.
+
+        When run as a script, Toga.run executes the TOGA pipeline from start to
+        finish. Alternatively, you may choose to run Toga.run interactively and
+        specifying which step to stop the execution at, with the up_to_and_incl
+        parameter. This is useful for debugging and development. For example,
+
+        >>> shutil.rmtree("test-HgbCgC2lD3", ignore_errors=True)
+        >>> args = parse_args([
+        ...     "test_input/align_micro_sample.chain",
+        ...     "test_input/annot_micro_sample.bed",
+        ...     "test_input/hg38.micro_sample.2bit",
+        ...     "test_input/q2bit_micro_sample.2bit", "--pn", "test-HgbCgC2lD3",
+        ...     "--kt", "--cjn", "1", "--chn", "1", "--ms"])
+        >>> toga_manager = Toga(args)
+        >>> toga_manager.run(0)
+        >>> os.path.isfile("test-HgbCgC2lD3/temp/genome_alignment.bst")
+        True
+        >>> os.path.isfile("test-HgbCgC2lD3/temp/chain_class_jobs_combined")
+        False"""
+        if up_to_and_incl is not None:
+            assert up_to_and_incl >= 0, \
+                f"up_to_and_incl is {up_to_and_incl} but must be >= 0"
+
         # 0) preparation:
         # define the project name and mkdir for it
         # move chain file filtered
@@ -569,11 +593,13 @@ class Toga:
         self.__make_indexed_chain()
         self.__make_indexed_bed()
         self.__time_mark("Made indexes")
+        if up_to_and_incl is not None and up_to_and_incl == 0: return None
 
         # 1) make joblist for chain features extraction
         to_log("\n\n#### STEP 1: Generate extract chain features jobs\n")
         self.__split_chain_jobs()
         self.__time_mark("Split chain jobs")
+        if up_to_and_incl is not None and up_to_and_incl == 1: return None
 
         # 2) extract chain features: parallel process
         to_log("\n\n#### STEP 2: Extract chain features: parallel step\n")
@@ -581,26 +607,31 @@ class Toga:
         self.__time_mark("Chain jobs done")
         to_log(f"Logs from individual chain runner jobs are show below")
         self.__collapse_logs("chain_runner_")
+        if up_to_and_incl is not None and up_to_and_incl == 2: return None
 
         # 3) create chain features dataset
         to_log("\n\n#### STEP 3: Merge step 2 output\n")
         self.__merge_chains_output()
         self.__time_mark("Chains output merged")
+        if up_to_and_incl is not None and up_to_and_incl == 3: return None
 
         # 4) classify chains as orthologous, paralogous, etc. using xgboost
         to_log("\n\n#### STEP 4: Classify chains using gradient boosting model\n")
         self.__classify_chains()
         self.__time_mark("Chains classified")
+        if up_to_and_incl is not None and up_to_and_incl == 4: return None
 
         # 5) create cluster jobs for CESAR2.0
         to_log("\n\n#### STEP 5: Generate CESAR jobs")
         # experimental feature, not publically available:
         self.__split_cesar_jobs()
         self.__time_mark("Split cesar jobs done")
+        if up_to_and_incl is not None and up_to_and_incl == 5: return None
 
         # 6) Create bed track for processed pseudogenes
         to_log("\n\n#### STEP 6: Create processed pseudogenes track\n")
         self.__get_proc_pseudogenes_track()
+        if up_to_and_incl is not None and up_to_and_incl == 6: return None
 
         # 7) call CESAR jobs: parallel step
         to_log("\n\n### STEP 7: Execute CESAR jobs: parallel step\n")
@@ -609,11 +640,13 @@ class Toga:
         self.__check_cesar_completeness()
         to_log(f"Logs from individual CESAR jobs are show below")
         self.__collapse_logs("cesar_")
+        if up_to_and_incl is not None and up_to_and_incl == 7: return None
 
         # 8) parse CESAR output, create bed / fasta files
         to_log("\n\n#### STEP 8: Merge STEP 7 output\n")
         self.__merge_cesar_output()
         self.__time_mark("Merged cesar output")
+        if up_to_and_incl is not None and up_to_and_incl == 8: return None
 
         # 9) classify projections/genes as lost/intact
         # also measure projections confidence levels
@@ -621,10 +654,12 @@ class Toga:
         # self.__transcript_quality()  # maybe remove -> not used anywhere
         self.__gene_loss_summary()
         self.__time_mark("Got gene loss summary")
+        if up_to_and_incl is not None and up_to_and_incl == 9: return None
 
         # 10) classify genes as one2one, one2many, etc orthologs
         to_log("\n\n#### STEP 10: Create orthology relationships table\n")
         self.__orthology_type_map()
+        if up_to_and_incl is not None and up_to_and_incl == 10: return None
 
         # 11) merge logs containing information about skipped genes,transcripts, etc.
         to_log("\n\n#### STEP 11: Cleanup: merge parallel steps output files")
@@ -1420,8 +1455,23 @@ class Toga:
         pass
 
 
-def parse_args():
-    """Read args, check."""
+def parse_args(arg_strs: list[str]=None):
+    """Parse arguments from the command line, or from a list of strings.
+
+    In this script, parse_args is called with the default arg_strs=None, which
+    leads it to read its argument list from the command line.
+
+    Alternatively, you can also called parse_args interactively by supplying
+    arguments as a list of strings in arg_strs. This is useful for debugging and
+    development. For example:
+
+    >>> args = parse_args([
+    ...     "test_input/align_micro_sample.chain",
+    ...     "test_input/annot_micro_sample.bed",
+    ...     "test_input/hg38.micro_sample.2bit",
+    ...     "test_input/q2bit_micro_sample.2bit", "--pn", "test-HgbCgC2lD3",
+    ...     "--kt", "--cjn", "1", "--chn", "1", "--ms"])
+    >>> toga_manager = Toga(args)"""
     app = argparse.ArgumentParser()
     app.add_argument(
         "chain_input",
@@ -1664,11 +1714,11 @@ def parse_args():
         )
     )
     # print help if there are no args
-    if len(sys.argv) < 2:
+    if not arg_strs and len(sys.argv) < 2:
         app.print_help()
         sys.exit(0)
 
-    args = app.parse_args()
+    args = app.parse_args(arg_strs)
     return args
 
 


### PR DESCRIPTION
Fixes #128 --- feedback welcome! :)

**Major changes:**
- nucleotide.fasta now outputs the CESAR2.0 exon alignments

**Minor changes:**
- Added an option to stop the pipeline at any step, when using toga.py interactively (rather than from the command line; this is useful mostly for debugging and development)
- Added some unit tests using the built-in doctest module
- Added some type hints
- Removed some unused function parameters

**How to test these changes:**
Run the doctest module like so:

```
$ python3 -m doctest -v modules/merge_cesar_output.py
```

The expected output is:

```
Trying:
    from pprint import pprint
Expecting nothing
ok
[...]
7 items had no tests:
    merge_cesar_output
    merge_cesar_output.get_excluded_genes
    merge_cesar_output.main
    merge_cesar_output.merge_cesar_output
    merge_cesar_output.parse_args
    merge_cesar_output.split_ex_reg_in_chrom
    merge_cesar_output.split_ex_reg_in_chrom__direction
3 items passed all tests:
   4 tests in merge_cesar_output.parse_cesar_out_file
   1 tests in merge_cesar_output.read_fasta
   1 tests in merge_cesar_output.read_region
6 tests in 10 items.
6 passed and 0 failed.
Test passed.
```

**Why doctest for a testing framework**

I wanted something that would not add complexity to the source code. To this end, doctest is probably the best option: it's a built-in standard library, the unit tests are written into function docstrings, and the test syntax is basically the same as copy-pasting from an interactive python session.